### PR TITLE
Add a bit about how many institutions were represented across both waves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ po/*~
 
 # RStudio Connect folder
 rsconnect/
+DART_analysis.Rproj

--- a/reports/notebooks/participant_count_and_attrition.Rmd
+++ b/reports/notebooks/participant_count_and_attrition.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Pariticpant counts and attrition"
+title: "Participant counts and attrition"
 author: "Rose Hartman"
 date: "`r Sys.Date()`"
 output: github_document
@@ -85,6 +85,15 @@ data |>
   knitr::kable()
 ```
 
+What about overall number of institutions across both waves?
+
+```{r}
+data |> 
+  dplyr::select(institution) |>
+  unique() |>
+  nrow()
+```
+
 Limited only to participants that made it all the way through the exit survey:
 
 ```{r}
@@ -95,6 +104,18 @@ data |>
   dplyr::count(wave, name = "n_institutions") |> 
   knitr::kable()
 ```
+
+Across both waves?
+
+```{r}
+data |> 
+  # limit only to participants that made it all the way through the exit survey
+  dplyr::filter(exit == 1) |> 
+  dplyr::select(institution) |>
+  unique() |>
+  nrow()
+```
+
 
 ## CHOP vs other institutions
 
@@ -109,6 +130,7 @@ data |>
 
 knitr::include_graphics(here::here("reports", "tables", "participant_n_by_chop.png"))
 ```
+
 ```{r}
 data |> 
   dplyr::select(wave, chop, needs_assessment, nih_pre, nih_post, exit) |> 

--- a/reports/notebooks/participant_count_and_attrition.md
+++ b/reports/notebooks/participant_count_and_attrition.md
@@ -1,4 +1,4 @@
-Pariticpant counts and attrition
+Participant counts and attrition
 ================
 Rose Hartman
 2024-03-22
@@ -25,6 +25,10 @@ Rose Hartman
 | Wave 1 |             24 |
 | Wave 2 |             72 |
 
+What about overall number of institutions across both waves?
+
+    ## [1] 78
+
 Limited only to participants that made it all the way through the exit
 survey:
 
@@ -33,7 +37,12 @@ survey:
 | Wave 1 |             15 |
 | Wave 2 |             41 |
 
+Across both waves?
+
+    ## [1] 43
+
 ## CHOP vs other institutions
 
 <img src="../tables/participant_n_by_chop.png" width="50%" />
+
 <img src="../tables/participant_n_by_phase_chop.png" width="50%" />


### PR DESCRIPTION
Just a couple of small changes here:

* Added something to .gitignore 
* Fixed a typo
* Added calculations for number of institutions represented across both waves (e.g. fixing the 'overlap' problem of knowing how many overall institutions were represented)